### PR TITLE
Register fonts using CTFontManagerRegisterFontsForURL

### DIFF
--- a/FontBlaster.swift
+++ b/FontBlaster.swift
@@ -113,17 +113,10 @@ private extension FontBlaster
         let fontName: FontPath = font.1
         let fontExtension: FontPath = font.2
 
-        if let
-            fontFileURL = NSBundle(path: fontPath)?.URLForResource(fontName, withExtension: fontExtension),
-            data = NSData(contentsOfURL: fontFileURL, options: .DataReadingMappedIfSafe, error: nil)
-        {
-            let provider = CGDataProviderCreateWithCFData(data)
-            let font = CGFontCreateWithDataProvider(provider)
-            
+        if let fontFileURL = NSBundle(path: fontPath)?.URLForResource(fontName, withExtension: fontExtension) {
             var fontError: Unmanaged<CFError>?
-            if CTFontManagerRegisterGraphicsFont(font, &fontError) {
-                let loadedFont = CGFontCopyPostScriptName(font)
-                printStatus("Successfully loaded font: '\(loadedFont)'.")
+            if CTFontManagerRegisterFontsForURL(fontFileURL, CTFontManagerScope.Process, &fontError) {
+                printStatus("Successfully loaded font: '\(fontName)'.")
             } else if let fontError = fontError?.takeRetainedValue() {
                 let errorDescription = CFErrorCopyDescription(fontError)
                 printStatus("Failed to load font '\(fontName)': \(errorDescription)")


### PR DESCRIPTION
The documentation for [CTFontManager](https://developer.apple.com/library/ios/documentation/Carbon/Reference/CoreText_FontManager_Ref/index.html#//apple_ref/c/func/CTFontManagerRegisterGraphicsFont) states: 

> Fonts that are backed by files should be registered using CTFontManagerRegisterFontsForURL.

This pull request replaces the usage of `CTFontManagerRegisterGraphicsFont` with `CTFontManagerRegisterFontsForURL`.
