### PR TITLE
Swift 2.3 Support

### DIFF
--- a/FontBlaster.swift
+++ b/FontBlaster.swift
@@ -104,17 +104,27 @@ private extension FontBlaster {
         - parameter path: The absolute path to the bundle.
     */
     class func loadFontsFromBundlesFoundInBundle(path: String) {
+
         do {
+
             let contents = try NSFileManager.defaultManager().contentsOfDirectoryAtPath(path)
+
             for item in contents {
-                if let url = NSURL(string: path) where item.containsString(".bundle") {
-                    let urlPath = url.URLByAppendingPathComponent(item)
-                    loadFontsForBundleWithPath(urlPath.absoluteString)
+
+                if let url = NSURL(string: path) where item.containsString(".bundle"),
+                    let urlPath = url.URLByAppendingPathComponent(item),
+                    urlPathString = urlPath.absoluteString {
+
+                        loadFontsForBundleWithPath(urlPathString)
+
                 }
+
             }
+
         } catch let error as NSError {
             printStatus(status: "There was an error accessing bundle with path. \nPath: \(path).\nError: \(error)")
         }
+
     }
     
     /**
@@ -135,8 +145,9 @@ private extension FontBlaster {
         var fontError: Unmanaged<CFError>?
         
         if let fontData = NSData(contentsOfURL: fontFileURL),
-            dataProvider = CGDataProviderCreateWithCFData(fontData),
-            fontRef = CGFontCreateWithDataProvider(dataProvider) {
+            dataProvider = CGDataProviderCreateWithCFData(fontData) {
+
+            let fontRef = CGFontCreateWithDataProvider(dataProvider)
 
             if CTFontManagerRegisterGraphicsFont(fontRef, &fontError) {
 

--- a/Sample Project/Font Blaster Sample Project.xcodeproj/project.pbxproj
+++ b/Sample Project/Font Blaster Sample Project.xcodeproj/project.pbxproj
@@ -224,14 +224,18 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Arthur Ariel Sabintsev";
 				TargetAttributes = {
 					5506979A1C685178008C5BAF = {
 						CreatedOnToolsVersion = 7.2.1;
+						DevelopmentTeam = HT94948NDD;
+						LastSwiftMigration = 0800;
 					};
 					8E7CBE8A1AF9BD7200009618 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = HT94948NDD;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -336,9 +340,11 @@
 		550697A41C685178008C5BAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -349,6 +355,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Sabintsev.FontBlaster;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -360,6 +367,7 @@
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -370,6 +378,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Sabintsev.FontBlaster;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -389,8 +399,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -434,8 +446,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -461,26 +475,31 @@
 		8E7CBEAB1AF9BD7200009618 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				INFOPLIST_FILE = "Font Blaster Sample Project/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sabintsev.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		8E7CBEAC1AF9BD7200009618 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				DEVELOPMENT_TEAM = HT94948NDD;
 				INFOPLIST_FILE = "Font Blaster Sample Project/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Sabintsev.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Sample Project/Font Blaster Sample Project.xcodeproj/xcshareddata/xcschemes/Font Blaster Sample Project.xcscheme
+++ b/Sample Project/Font Blaster Sample Project.xcodeproj/xcshareddata/xcschemes/Font Blaster Sample Project.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sample Project/Font Blaster Sample Project.xcodeproj/xcshareddata/xcschemes/FontBlaster.xcscheme
+++ b/Sample Project/Font Blaster Sample Project.xcodeproj/xcshareddata/xcschemes/FontBlaster.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Converted code base to Swift 2.3 using Xcode8b4.

Please note that when Xcode 8 GM comes out, the `master` branch will begin pointing to the Swift 3 code base that is currently found on the `swift3` branch.
