### PR TITLE
Use String directly, instead of String.characters

### DIFF
--- a/Sources/FontBlaster.swift
+++ b/Sources/FontBlaster.swift
@@ -167,7 +167,7 @@ private extension FontBlaster {
     /// 
     /// - Returns: A tuple with the font's name and extension.
     class func font(fromName name: String) -> (FontName, FontExtension) {
-        let components = name.characters.split{$0 == "."}.map { String($0) }
+        let components = name.split{$0 == "."}.map { String($0) }
         return (components[0], components[1])
     }
 


### PR DESCRIPTION
As of Swift 4, String is a collection of characters again: https://github.com/apple/swift/blob/master/docs/StringManifesto.md#string-should-be-a-collection-of-characters-again

There is no longer any need to use String.characters, and Xcode displays the following warning when you do so: FontBlaster.swift:170:31: 'characters' is deprecated: Please use String or Substring directly