### PR TITLE
Fixed a crash when opening certain fonts

### DIFF
--- a/Sources/FontBlaster.swift
+++ b/Sources/FontBlaster.swift
@@ -100,10 +100,13 @@ private extension FontBlaster {
         if let fontData = try? Data(contentsOf: fontFileURL) as CFData,
             let dataProvider = CGDataProvider(data: fontData) {
 
-            let fontRef = CGFont(dataProvider)
+            guard let fontRef = CGFont(dataProvider) else {
+                printDebugMessage(message: "Failed to load font: '\(fontName)': fontRef is nil")
+                return
+            }
 
-            if CTFontManagerRegisterGraphicsFont(fontRef!, &fontError),
-               let postScriptName = fontRef?.postScriptName {
+            if CTFontManagerRegisterGraphicsFont(fontRef, &fontError),
+               let postScriptName = fontRef.postScriptName {
                     printDebugMessage(message: "Successfully loaded font: '\(postScriptName)'.")
                     loadedFonts.append(String(postScriptName))
             } else if let fontError = fontError?.takeRetainedValue() {


### PR DESCRIPTION
The forced unwrap in line 105 can fail for certain kinds of fonts. This change handles that.