### PR TITLE
Look for fonts recursively in bundle

### DIFF
--- a/Sources/FontBlaster.swift
+++ b/Sources/FontBlaster.swift
@@ -136,17 +136,32 @@ private extension FontBlaster {
     /// 
     /// - Returns: A an array of Font objects.
     final class func fonts(fromPath path: String, withContents contents: [String]) -> [Font] {
+        printDebugMessage(message: "\nScanning \(path) with contents: \n \(contents)")
         var fonts = [Font]()
-        for fontName in contents {
+        for fileName in contents {
             var parsedFont: (FontName, FontExtension)?
 
-            if fontName.contains(SupportedFontExtensions.TrueTypeFont.rawValue) || fontName.contains(FontBlaster.SupportedFontExtensions.OpenTypeFont.rawValue) {
-                parsedFont = font(fromName: fontName)
+            if fileName.contains(SupportedFontExtensions.TrueTypeFont.rawValue) || fileName.contains(FontBlaster.SupportedFontExtensions.OpenTypeFont.rawValue) {
+                parsedFont = font(fromName: fileName)
             }
 
             if let parsedFont = parsedFont {
                 let font: Font = (path, parsedFont.0, parsedFont.1)
                 fonts.append(font)
+            }
+
+            let fileURL = URL(fileURLWithPath: "\(path)/\(fileName)")
+            let isDir = (
+                try? fileURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory
+            ) ?? false
+            
+            if isDir {
+                let contents: [String] = (
+                    try? FileManager.default.contentsOfDirectory(atPath: fileURL.path)
+                ) ?? []
+                let subDirFonts = Self.fonts(fromPath: fileURL.path,
+                                             withContents: contents)
+                fonts.append(contentsOf: subDirFonts)
             }
         }
 


### PR DESCRIPTION
Hi, I've noticed that when using FontBlaster as a dependency of  my library Swift package:
- Everything works fine as long as you use iOS platform with `.module` bundle
- FontBlaster is not able to find any of my resources when using macOS platform with `.module` bundle

The reason for that are resources embedded under `Contents` directory that keep the original directory structure:

My bundle:
`/Users/kondratk/Library/Developer/Xcode/DerivedData/MyPackage-dxbwrokqznyjxecogbundkgodlnd/Build/Products/Debug/MyPackageTests.xctest/Contents/Resources/MyPackage_MyPackage.bundle`

which contains:

```
└── Contents
    ├── Info.plist
    └── Resources
        ├── Font1.ttf
        ├── Font2.ttf
        ├── Font3.ttf
        ...
```

As an effect of my Target configuration:

```
        .target(
            name: "MyPackage",
            dependencies: ["FontBlaster"],
            resources: [.process("Resources/")]
        ),
```

For comparison, the same package with the same Package.swift configuration bundles resources differently on iOS. They are copied at root level:
My bundle:

`/Users/kondratk/Library/Developer/Xcode/DerivedData/MyPackage-dxbwrokqznyjxecogbundkgodlnd/Build/Products/Debug-iphonesimulator/MyPackageTests.xctest/MyPackage_MyPackage.bundle`

and its contents:

```
├── Info.plist
├── Font1.ttf
├── Font2.ttf
├── Font3.ttf
└── _CodeSignature
    ├── CodeDirectory
    ├── CodeRequirements
    ├── CodeRequirements-1
    ├── CodeResources
    └── CodeSignature
```

To solve this problem and make the solution a little more flexible, I've implemented recursive call of your `fonts(fromPath: String, withContents: [String])` function.

